### PR TITLE
ReStock SSME thrust fix

### DIFF
--- a/GameData/NF_Realism/Patches/ReStock/Vector_RS25.cfg
+++ b/GameData/NF_Realism/Patches/ReStock/Vector_RS25.cfg
@@ -16,7 +16,7 @@
 
   @MODULE[ModuleEnginesFX]
   {
-    @maxThrust = 465 //109% throttle
+    @maxThrust = 570 //25% thrust scaling. 2,278.8 kN @ 109% throttle.
     @PROPELLANT[LiquidFuel]
     {
       @name = LqdHydrogen
@@ -29,7 +29,7 @@
     !atmosphereCurve {}
     atmosphereCurve
     {
-      key = 0 452 0 0
+      key = 0 452.3 0 0
       key = 1 366 0 0
       key = 5 0.1 0 0
     }


### PR DESCRIPTION
Changed SSME thrust to 25% of vacuum thrust and increased Isp to 452.3 according to source.

Source: https://www.rocket.com/sites/default/files/documents/lr_3-26-19_RS25_data%20sheet.pdf