### PR TITLE
RS-68A switch for CryoEngines RS-68

### DIFF
--- a/GameData/NF_Realism/Patches/CryoEngines/Etna_RS68.cfg
+++ b/GameData/NF_Realism/Patches/CryoEngines/Etna_RS68.cfg
@@ -1,36 +1,95 @@
 @PART[cryoengine-etna-1]:NEEDS[CryoEngines]:FOR[NF_Realism]
 {
-    // model nozzle diameter = 1.67 m
-    // real nozzle diameter = 2.44 m
-    // to get 0.625x we would want a scale of 0.912, but to make the mount 3.125 m we use 0.8333333
-    @rescaleFactor = 0.8333333
-    @mass = 4.455 // real mass 6600 kg
-    @bulkheadProfiles = size2p5, srf
-    %tags = Etna RS68 Delta IV 4  
+  // Title and description
 
-    @MODULE[ModuleEngines*]
+  real_title = RS-68 Cryogenic Engine
+  real_manufacturer = Aerojet Rocketdyne
+  real_description = The most powerful hydrogen-fueled rocket engine in the world, the RS-68 is a cheaper but less efficient alternative to the RS-25. Ideal for heavy-lift expendable launch vehicles.
+
+  //Specs
+
+  // model nozzle diameter = 1.67 m
+  // real nozzle diameter = 2.44 m
+  // to get 0.625x we would want a scale of 0.912, but to make the mount 3.125 m we use 0.8333333
+  @rescaleFactor = 0.8333333
+  @mass = 4.455 // real mass 6600 kg
+  @bulkheadProfiles = size2p5, srf
+  %tags = Etna RS68 Delta IV 4
+
+  @MODULE[ModuleEngines*]
+  {
+      @maxThrust = 842.5
+
+      !atmosphereCurve {}
+      atmosphereCurve
+      {
+          key = 0 409
+          key = 1 357
+      }
+  }
+
+  @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[meshSwitch]]
+  {
+      @SUBTYPE[3.75m]
+      {
+          @title ^= :3([\.,])75:3$1####125:
+          @title ^= :####::
+          @descriptionSummary ^= :3([\.,])75:3$1####125:
+          @descriptionSummary ^= :####::
+      }
+  }
+
+  MODULE
+  {
+    name = ModuleB9PartSwitch
+    switcherDescription = Engine Config
+    switcherDescriptionPlural = Engine Configs
+    moduleID = engineSwitch
+
+    SUBTYPE
     {
-        @maxThrust = 842.5
-
-        !atmosphereCurve {}
-        atmosphereCurve
-        {
-            key = 0 409
-            key = 1 357
-        }
+      name = RS-68
+      title = CR-68
+      descriptionSummary = Original CR-68.
+      real_title = RS-68
+      real_descriptionSummary = Original RS-68.
+      descriptionDetail = <b>Thrust:</b> 735.4 kN ASL / 842.5 kN Vac.\n<b>Isp:</b> 357 s ASL / 409 s Vac.
+      defaultSubtypePriority = 0
     }
 
-    @MODULE[ModuleB9PartSwitch]:HAS[#moduleID[meshSwitch]]
+    SUBTYPE
     {
-        @SUBTYPE[3.75m]
+      name = RS-68A
+      title = CR-68A
+      descriptionSummary = Improved version of the CR-68, providing 48kN of additional thrust at lift-off.
+      real_title = RS-68A
+      real_descriptionSummary = Improved version of the RS-68, providing 48kN of additional thrust at lift-off.
+      descriptionDetail = <b>Thrust:</b> 783.6 kN ASL / 889.7 kN Vac.\n<b>Isp:</b> 362 s ASL / 411 s Vac.
+      defaultSubtypePriority = 1
+
+      MODULE
+      {
+        IDENTIFIER
         {
-            @title ^= :3([\.,])75:3$1####125:
-            @title ^= :####::
-            @descriptionSummary ^= :3([\.,])75:3$1####125:
-            @descriptionSummary ^= :####::
+          name = ModuleEnginesFX
         }
+
+        DATA
+        {
+          maxThrust = 889.7 // 25% thrust scaling. 3,558.6 kN.
+
+          atmosphereCurve
+          {
+            key = 0 411
+            key = 1 362
+            key = 12 0.001
+          }
+        }
+      }
     }
+  }
 }
+
 @PART[cryoengine-etna-1]:NEEDS[RealPlume,SmokeScreen]:AFTER[zzRealPlume]
 {
   @EFFECTS


### PR DESCRIPTION
- Added RS-68A switch for RS-68 (Etna). Specs from Aerojet Rocketdyne's RS-68A Data Sheet (https://www.rocket.com/sites/default/files/documents/RS-68A_data_sheet.pdf)

- Added real title, manufacturer and description.

- Removed extra indent.