### PR TITLE
RS-25 and Merlin 1D/Vac tweaks and variants

### DIFF
--- a/GameData/NF_Realism/Patches/NearFutureLaunchVehicles/Merlin1D.cfg
+++ b/GameData/NF_Realism/Patches/NearFutureLaunchVehicles/Merlin1D.cfg
@@ -1,15 +1,112 @@
 @PART[nflv-engine-m1d-1]:NEEDS[NearFutureLaunchVehicles]:FOR[NF_Realism]
 {
-    @mass = 0.32
+  // Title and description
 
-    @MODULE[ModuleEngines*]
+  real_title = Merlin 1D
+  real_manufacturer = SpaceX
+  real_description = The Merlin 1D is a modern but simple gas generator engine capable of multiple restarts. Its compact size allows for clustering, giving it great flexibility for booster applications. Nine of these engines are used on the Falcon 9 first stage.
+
+  // Specs
+
+  // model nozzle diameter = 0.42123 m
+  // real nozzle diameter = ~0.95 m
+  // to get 0.625x we would want a scale of 1.4, but to make the mount 0.9375 m we use 1.5
+
+  @rescaleFactor = 1.5
+  @mass = 0.343 // 73%, 470 Kg. Merlin 1C
+  @bulkheadProfiles = size0p5, srf
+
+  @MODULE[ModuleEngines*]
+  {
+      @maxThrust = 185.6 // 25% thrust scaling. 742.4 kN.
+
+      !atmosphereCurve {}
+      atmosphereCurve
+      {
+          key = 0 311
+          key = 1 282
+          key = 5 0.1
+      }
+  }
+
+  MODULE
+  {
+    name = ModuleB9PartSwitch
+    switcherDescription = Engine Config
+    switcherDescriptionPlural = Engine Configs
+    moduleID = engineSwitch
+
+    SUBTYPE
     {
-        @maxThrust = 245.25
-        !atmosphereCurve {}
-        atmosphereCurve
-        {
-            key = 0 311
-            key = 1 282
-        }
+      name = M1D
+      title = KS-1M
+      descriptionSummary = Baseline version of the KS-1M engine.
+      real_title = Merlin 1D
+      real_descriptionSummary = Baseline version of the Merlin 1D, as used on the Falcon 9 v1.1.
+      descriptionDetail = <b>Thrust:</b> 168.3 kN ASL / 185.6 kN Vac.\n<b>Isp:</b> 282 s ASL / 311 s Vac.
+      defaultSubtypePriority = 0
     }
+
+    SUBTYPE
+    {
+      name = M1D-P
+      title = KS-1M+
+      descriptionSummary = Thrust and efficiency improvements.
+      real_title = Merlin 1D+
+      real_descriptionSummary = Thrust and efficiency improvements. Used on the Falcon 9 v1.2, also known as Full Thrust.
+      descriptionDetail = <b>Thrust:</b> 211.3 kN ASL / 228.5 kN Vac.\n<b>Isp:</b> 288.5 s ASL / 312 s Vac.
+      defaultSubtypePriority = 1
+
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleEnginesFX
+        }
+
+        DATA
+        {
+          maxThrust = 228.5 // 25% thrust scaling. 914.1 kN.
+
+          atmosphereCurve
+          {
+            key = 0 312
+            key = 1 288.5
+            key = 5 0.1
+          }
+        }
+      }
+    }
+
+    SUBTYPE
+    {
+      name = M1D-PP
+      title = KS-1M++
+      descriptionSummary = Improved model with even higher thrust and efficiency.
+      real_title = Merlin 1D++
+      real_descriptionSummary = Improved model with even higher thrust and efficiency. Powerplant of the Falcon 9 Block 5 first stage.
+      descriptionDetail = <b>Thrust:</b> 225.8 kN ASL / 244.7 kN Vac.\n<b>Isp:</b> 290 s ASL / 314.3 s Vac.
+      defaultSubtypePriority = 2
+
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleEnginesFX
+        }
+
+        DATA
+        {
+          maxThrust = 244.7 // 25% thrust scaling. 978.6 kN.
+
+          atmosphereCurve
+          {
+            key = 0 314.3
+            key = 1 290
+            key = 5 0.1
+          }
+        }
+      }
+    }
+  }
 }

--- a/GameData/NF_Realism/Patches/NearFutureLaunchVehicles/MerlinVac.cfg
+++ b/GameData/NF_Realism/Patches/NearFutureLaunchVehicles/MerlinVac.cfg
@@ -1,15 +1,81 @@
 @PART[nflv-engine-m1d-vac-1]:NEEDS[NearFutureLaunchVehicles]:FOR[NF_Realism]
 {
-    @mass = 0.32
+    // Title and description
+
+    real_title = Merlin 1D Vacuum
+    real_manufacturer = SpaceX
+    real_description = Vacuum optimized version of the Merlin 1D, featuring a film-cooled Niobium alloy nozzle extension for increased vacuum efficiency. 
+    
+    // Specs
+
+    // model nozzle diameter = 0.95 m
+    // real nozzle diameter = ~2.5 m (area is 4.9 m^2)
+    // to get 0.625x we would want a scale of 1.645, but to make the mount 1.875 m (and keep the scale consistent with the SL Merlin 1D) we use 1.5
+
+    @rescaleFactor = 1.5
+    @mass = 0.36 // 73%, 490 Kg.
+    @bulkheadProfiles = size1p5, srf
 
     @MODULE[ModuleEngines*]
     {
-        @maxThrust = 245.25
+        @maxThrust = 201.3 // 25% thrust scaling. 805.13 kN (181,000 lbf).
+
         !atmosphereCurve {}
         atmosphereCurve
         {
-            key = 0 348
-            key = 1 0.01
+            key = 0 347
+            key = 1 80
+            key = 3 0.1
+        }
+    }
+
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        switcherDescription = Engine Config
+        switcherDescriptionPlural = Engine Configs
+        moduleID = engineSwitch
+
+        SUBTYPE
+        {
+            name = M1DV
+            title = KS-1M-V
+            descriptionSummary = Baseline version of the KS-1M Vac engine.
+            real_title = Merlin 1DV
+            real_descriptionSummary = Baseline version of the Merlin 1D Vac, as used on the Falcon 9 v1.1.
+            descriptionDetail = <b>Thrust:</b> 46.4 kN ASL / 201.3 kN Vac.\n<b>Isp:</b> 80 s ASL / 347 s Vac.
+            defaultSubtypePriority = 0
+        }
+
+        SUBTYPE
+        {
+            name = M1DV-P
+            title = KS-1M-V+
+            descriptionSummary = Thrust and efficiency improvements.
+            real_title = Merlin 1DV+
+            real_descriptionSummary = Thrust and efficiency improvements. Used on the Falcon 9 v1.2, also known as Full Thrust.
+            descriptionDetail = <b>Thrust:</b> 53.7 kN ASL / 228.5 kN Vac.\n<b>Isp:</b> 80 s ASL / 348 s Vac.
+            defaultSubtypePriority = 1
+
+            MODULE
+            {
+                IDENTIFIER
+                {
+                    name = ModuleEnginesFX
+                }
+
+                DATA
+                {
+                    maxThrust = 233.5 // 25% thrust scaling. 934.13 kN (210,000 lbf).
+
+                    atmosphereCurve
+                    {
+                        key = 0 348
+                        key = 1 80
+                        key = 3 0.1
+                    }
+                }
+            }
         }
     }
 }

--- a/GameData/NF_Realism/Patches/ReStock/Vector_RS25.cfg
+++ b/GameData/NF_Realism/Patches/ReStock/Vector_RS25.cfg
@@ -16,22 +16,106 @@
 
   @MODULE[ModuleEnginesFX]
   {
-    @maxThrust = 570 //25% thrust scaling. 2,278.8 kN @ 109% throttle.
+    @maxThrust = 522.5 //25% thrust scaling. 2,090 kN @ 100% throttle.
+
     @PROPELLANT[LiquidFuel]
     {
       @name = LqdHydrogen
       @ratio = 1.5
     }
+
     @PROPELLANT[Oxidizer]
     {
       @ratio = 0.1
     }
+
     !atmosphereCurve {}
     atmosphereCurve
     {
-      key = 0 452.3 0 0
-      key = 1 366 0 0
+      key = 0 454.4 0 0
+      key = 1 362.4 0 0
       key = 5 0.1 0 0
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleB9PartSwitch
+    switcherDescription = Engine Config
+    switcherDescriptionPlural = Engine Configs
+    moduleID = engineSwitch
+
+    SUBTYPE
+    {
+      name = RS-25
+      title = KS-25 Baseline
+      descriptionSummary = Baseline version of the KS-25.
+      real_title = RS-25 Baseline
+      real_descriptionSummary = Baseline version of the RS-25, as used on the initial orbital flights of the Space Shuttle.
+      descriptionDetail = <b>Thrust:</b> 416.7 kN ASL / 522.5 kN Vac.\n<b>Isp:</b> 362.4 s ASL / 454.4 s Vac.
+      defaultSubtypePriority = 0
+    }
+
+    SUBTYPE
+    {
+      name = RS-25-PI
+      title = KS-25 Phase I
+      descriptionSummary = Several design changes, specially to the turbopumps, allow the thrust to be increased to 104%.
+      real_title = RS-25 Phase I
+      real_descriptionSummary = Several design changes, specially to the turbopumps, allow the thrust to be increased to 104%.
+      descriptionDetail = <b>Thrust:</b> 433.6 kN ASL / 543.4 kN Vac.\n<b>Isp:</b> 363.2 s ASL / 455.2 s Vac.
+      defaultSubtypePriority = 1
+
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleEnginesFX
+        }
+
+        DATA
+        {
+          maxThrust = 543.4 // 25% thrust scaling. 2,173.6 kN @ 104% throttle.
+
+          atmosphereCurve
+          {
+            key = 0 455.2 0 0
+            key = 1 363.2 0 0
+            key = 5 0.1 0 0
+          }
+        }
+      }
+    }
+
+    SUBTYPE
+    {
+      name = RS-25-BIIA
+      title = KS-25 Block IIA
+      descriptionSummary = Certified for 104.5% thrust, this engine operates at lower pressures and temperatures thanks to its larger throat diameter.
+      real_title = RS-25 Block IIA
+      real_descriptionSummary = Certified for 104.5% thrust, this engine operates at lower pressures and temperatures thanks to its larger throat diameter.
+      descriptionDetail = <b>Thrust:</b> 442.2 kN ASL / 546 kN Vac.\n<b>Isp:</b> 366.3 s ASL / 452.3 s Vac.
+      defaultSubtypePriority = 2
+
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleEnginesFX
+        }
+
+        DATA
+        {
+          maxThrust = 546 // 25% thrust scaling. 2,184.05 kN @ 104.5% throttle.
+
+          atmosphereCurve
+          {
+            key = 0 452.3 0 0
+            key = 1 366.3 0 0
+            key = 5 0.1 0 0
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
As mentioned on the previous (closed) pull request, added RS-25 variants (baseline, 104% and 104.5% thrust).

Rescaled Merlin 1D and Merlin 1D Vac, added real title, manufacturer and description. Also added variants for both engines.

Sources for Merlin engines:

- http://www.b14643.de/Spacerockets_2/United_States_1/Falcon-9/Merlin/index.htm (Performance values. Merlin 1D vacuum Isp is incorrect)

- https://forum.nasaspaceflight.com/index.php?topic=32983.45 (Merlin 1D nozzle diameter estimates)

- Realism Overhaul configs for engine mass.